### PR TITLE
Configurable Maven executables

### DIFF
--- a/maven3-plugin/pom.xml
+++ b/maven3-plugin/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.hudsonci.plugins</groupId>
         <artifactId>hudson-maven3</artifactId>
-        <version>3.0.1a-SNAPSHOT</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>maven3-plugin</artifactId>


### PR DESCRIPTION
...ernal/MavenInstallationValidator.java

Check for maven.executable.win and maven.executable.nix in EnvVars and make them executables instead of looking for executables in M2_HOME/bin.
This allows hooking into Maven execution by extending classworlds' "classpath" with custom jars containing additional listeners.
