### PR TITLE
Set permissions correctly on bundled Maven instance

### DIFF
--- a/maven3-slavebundle/src/main/assembly/bundle.xml
+++ b/maven3-slavebundle/src/main/assembly/bundle.xml
@@ -46,6 +46,22 @@ THE SOFTWARE.
             <includes>
                 <include>**</include>
             </includes>
+            <excludes>
+                <exclude>bin/mvn</exclude>
+                <exclude>bin/mvnDebug</exclude>
+                <exclude>bin/mvnyjp</exclude>
+            </excludes>
+        </fileSet>
+
+        <fileSet>
+            <directory>target/apache-maven-${mavenVersion}</directory>
+            <outputDirectory>/bundled-maven</outputDirectory>
+            <includes>
+                <include>bin/mvn</include>
+                <include>bin/mvnDebug</include>
+                <include>bin/mvnyjp</include>
+            </includes>
+            <fileMode>0755</fileMode>
         </fileSet>
 
         <fileSet>


### PR DESCRIPTION
The mvn script in the 3.0.2 release doesn't have executable permission.
