### PR TITLE
Bug 395725 - White space not ignored when specifying a pom.xml

### DIFF
--- a/maven3-plugin/src/main/java/org/hudsonci/maven/plugin/builder/internal/BuildConfigurationExtractor.java
+++ b/maven3-plugin/src/main/java/org/hudsonci/maven/plugin/builder/internal/BuildConfigurationExtractor.java
@@ -92,7 +92,7 @@ public class BuildConfigurationExtractor
         config.setInstallationId(getString("installationId"));
         config.setGoals(getString("goals"));
         config.setProperties(getProperties("properties"));
-        config.setPomFile(getString("pomFile"));
+        config.setPomFile(getString("pomFile").trim());
         config.setPrivateRepository(getBoolean("privateRepository"));
         config.setPrivateTmpdir(getBoolean("privateTmpdir"));
         config.setOffline(getBoolean("offline"));


### PR DESCRIPTION
Trim whitespace on pom.xml configuration box.
